### PR TITLE
fix br tag handling in plain-format-html

### DIFF
--- a/toolkit.lisp
+++ b/toolkit.lisp
@@ -148,7 +148,7 @@
     (cl-ppcre:regex-replace-all
      "&\\w+;"
      (r "<([^>]*)>" ""
-        (r "<br />" (string #\Linefeed)
+        (r "<br\\s*/>" (string #\Linefeed)
            string))
      (lambda (string s e ms me rs re)
        (declare (ignore s e rs re))


### PR DESCRIPTION
Since HTML attributes can have any whitespace in between attributes, change the space to `\\s`. I also added `*` instead of `+` because I've seen `<br/>` (with no space) in some toots.