### PR TITLE
added function to translate 'parent' slot of entity status.

### DIFF
--- a/objects.lisp
+++ b/objects.lisp
@@ -262,7 +262,7 @@
   (account :translate-with #'decode-account)
   (in-reply-to-id :nullable T)
   (in-reply-to-account-id :nullable T)
-  (parent :field "reblog" :nullable T)
+  (parent :field "reblog" :nullable T :translate-with #'decode-status)
   (content)
   (created-at :translate-with #'convert-timestamp)
   (emojis :translate-with #'decode-emoji)


### PR DESCRIPTION
Hello!

Seems that the 'parent' slot of entity status was not decoded (it is an hashmap), probably could be useful to translate it to get a proper entity.

Hope this is correct, if not ~fell~ feel free to throw away this PR , of course! :)

Bye!
C.