### PR TITLE
Added print object tag history

### DIFF
--- a/objects.lisp
+++ b/objects.lisp
@@ -56,6 +56,7 @@
   (account-name :field "acct")
   (display-name)
   (locked)
+  (discoverable)
   (created-at :translate-with #'convert-timestamp)
   (followers-count)
   (following-count)

--- a/objects.lisp
+++ b/objects.lisp
@@ -343,6 +343,15 @@
   (use-count :field "uses")
   (account-count :field "accounts"))
 
+(defmethod print-object ((tag-history tag-history) stream)
+  (print-unreadable-object (tag-history stream :type T)
+    (with-accessors ((day day)
+                     (use-count use-count)
+                     (account-count account-count)) tag-history
+      (format stream
+              "day: ~a use-count: ~a account-count: ~a"
+              day use-count account-count))))
+
 (define-entity conversation
   (id)
   (accounts :translate-with #'decode-account)

--- a/package.lisp
+++ b/package.lisp
@@ -17,6 +17,7 @@
    #:account-name
    #:display-name
    #:locked
+   #:discoverable
    #:created-at
    #:followers-count
    #:following-count


### PR DESCRIPTION
Hi Shinmera!

This method was missing from a previous PR.
Nothing vital but added for consistency.

Bye!
C.