### PR TITLE
Readded deprecated delete notification

### DIFF
--- a/documentation.lisp
+++ b/documentation.lisp
@@ -2002,6 +2002,22 @@ Returns T.
 See NOTIFICATION
 See CLIENT")
 
+  (function delete-notification-deprecated
+    "Delete or dismiss a single notification.
+
+The notification can either be a NOTIFICATION instance or a notification ID.
+
+Returns T.
+
+This function is deprecated and works only for instances of mastodon with version < 3.0.
+
+Anyway this function must be used to delete single notification if the client
+is connected to a an instance running pleroma version <= 2.0.
+
+See NOTIFICATION
+See CLIENT")
+
+
   (function make-subscription
     "Create or update a push notification subscription.
 

--- a/objects.lisp
+++ b/objects.lisp
@@ -56,6 +56,7 @@
   (account-name :field "acct")
   (display-name)
   (locked)
+  (discoverable)
   (created-at :translate-with #'convert-timestamp)
   (followers-count)
   (following-count)

--- a/package.lisp
+++ b/package.lisp
@@ -314,7 +314,6 @@
    #:notifications
    #:find-notification
    #:delete-notification
-   #:delete-notification-deprecated
    #:make-subscription
    #:subscription
    #:delete-subscription
@@ -378,6 +377,22 @@
    #:universal->utc-timestring
    #:plain-format-html))
 
+(defpackage #:tooter-pleroma-objects
+  (:nicknames #:org.shirakumo.tooter.pleroma.objects)
+  (:use #:tooter-objects)
+  ;; objects.lisp
+  (:export))
+
+(defpackage #:tooter-pleroma-queries
+  (:nicknames #:org.shirakumo.tooter.pleroma.queries)
+  (:use #:tooter-objects
+        #:tooter-queries
+        #:tooter-pleroma-objects)
+  (:shadow #:delete-notification)
+  ;; queries.lisp
+  (:export
+   #:delete-notification))
+
 (defpackage #:tooter
   (:nicknames #:org.shirakumo.tooter)
   (:use #:cl #:tooter-objects #:tooter-queries #:tooter-client)
@@ -386,3 +401,11 @@
 (dolist (package '(#:tooter-objects #:tooter-queries #:tooter-client))
   (do-symbols (symbol package)
     (export symbol '#:tooter)))
+
+(defpackage #:tooter-pleroma
+  (:nicknames #:org.shirakumo.tooter.pleroma)
+  (:use #:cl #:tooter)
+  (:shadowing-import-from #:tooter-queries #:block)
+  (:shadowing-import-from #:tooter-pleroma-queries #:delete-notification)
+  (:export
+   #:delete-notification))

--- a/package.lisp
+++ b/package.lisp
@@ -17,6 +17,7 @@
    #:account-name
    #:display-name
    #:locked
+   #:discoverable
    #:created-at
    #:followers-count
    #:following-count

--- a/package.lisp
+++ b/package.lisp
@@ -314,6 +314,7 @@
    #:notifications
    #:find-notification
    #:delete-notification
+   #:delete-notification-deprecated
    #:make-subscription
    #:subscription
    #:delete-subscription

--- a/pleroma/queries.lisp
+++ b/pleroma/queries.lisp
@@ -1,0 +1,17 @@
+#|
+ This file is a part of Tooter
+ (c) 2018 Shirakumo http://tymoon.eu (shinmera@tymoon.eu)
+ Author: Nicolas Hafner <shinmera@tymoon.eu>
+|#
+
+(in-package #:org.shirakumo.tooter.pleroma)
+
+;;; Notifications
+
+(defmethod delete-notification ((client client) (id string))
+  (submit client "/api/v1/notifications/dismiss"
+          :id id)
+  T)
+
+(defmethod delete-notification ((client client) (notification notification))
+  (delete-notification client (id notification)))

--- a/queries.lisp
+++ b/queries.lisp
@@ -553,18 +553,20 @@
   (unmute-conversation client (id status)))
 
 ;;; Timelines
-(defun %timeline (client url &key (local NIL l-p) (only-media NIL o-p) max-id since-id (limit 20))
+(defun %timeline (client url &key (local NIL l-p) (only-media NIL o-p) max-id since-id min-id (limit 20))
   (check-type max-id (or null string))
   (check-type since-id (or null string))
+  (check-type min-id (or null string))
   (check-type limit (or null (integer 0)))
   (decode-status (query client (format NIL "/api/v1/timelines/~a" url)
                         :local (coerce-boolean local l-p)
                         :only-media (coerce-boolean only-media o-p)
                         :max-id max-id
                         :since-id since-id
+                        :min-id min-id
                         :limit limit)))
 
-(defgeneric timeline (client kind &key local only-media max-id since-id limit))
+(defgeneric timeline (client kind &key local only-media max-id since-id limit min-id))
 
 (defmethod timeline ((client client) (kind (eql :home)) &rest args)
   (apply #'%timeline client "home" args))

--- a/queries.lisp
+++ b/queries.lisp
@@ -440,6 +440,14 @@
 (defmethod delete-notification ((client client) (notification notification))
   (delete-notification client (id notification)))
 
+(defmethod delete-notification-deprecated ((client client) (id string))
+  (submit client "/api/v1/notifications/dismiss"
+          :id id)
+  T)
+
+(defmethod delete-notification-deprecated ((client client) (notification notification))
+  (delete-notification-deprecated client (id notification)))
+
 (defmethod make-subscription ((client client) endpoint public-key secret &key alerts)
   (check-type endpoint string)
   (check-type public-key string)

--- a/tooter.asd
+++ b/tooter.asd
@@ -17,6 +17,8 @@
                (:file "client")
                (:file "objects")
                (:file "queries")
+               (:module pleroma
+                        :components ((:file "queries")))
                (:file "documentation"))
   :depends-on (:yason
                :cl-ppcre


### PR DESCRIPTION
Hi Shinmera!

I noticed I was not able to delete single notifications on a pleroma instance I use as test. Turned out that the problem was that pleroma still uses old mastodon API version and is unable to understand the request with the new format. This will change in the future when pleroma devs will implement the API provided by the 3.0 version of mastodon. In the meanwhile i thought was useful to reintroduce the old API for people connecting with pleroma.

I have named the new methods `delete-notification-deprecated` and tried to explain why this method exits in the documentation. But i feel this is a not too elegant way to deal with deprecated stuff. Should i put all the deprecated functions/object in another file? Or even in another package (like `tooter-deprecated`)?

I am open to suggestions! :)

Bye!
C.