### PR TITLE
Correctly match <br> elements in html

### DIFF
--- a/toolkit.lisp
+++ b/toolkit.lisp
@@ -155,7 +155,7 @@
     (cl-ppcre:regex-replace-all
      "&\\w+;"
      (r "<([^>]*)>" ""
-        (r "<br\s*>" (string #\Linefeed)
+        (r "<br\\s*?/?>" (string #\Linefeed)
            string))
      (lambda (string s e ms me rs re)
        (declare (ignore s e rs re))


### PR DESCRIPTION
The regex was a bit off, which caused <br> elements to get deleted altogether with other html elements