### PR TITLE
ensured decoding of hashtags results after a search query (returned by 'find-results').

### DIFF
--- a/documentation.lisp
+++ b/documentation.lisp
@@ -1303,10 +1303,11 @@ See RESULTS")
 
 See RESULTS")
 
-  (function hashtags
-    "Returns a list of matching hashtags as strings.
+  (function results-tags
+    "Returns a list of matching hashtags as TAGS.
 
-See RESULTS")
+See RESULTS
+See TAGS")
 
   (type status-params
      "Representation of parameters for a SCHEDULED-STATUS.

--- a/objects.lisp
+++ b/objects.lisp
@@ -453,14 +453,15 @@
 (define-entity results
   (results-accounts :field "accounts" :translate-with #'decode-account)
   (results-statuses :field "statuses" :translate-with #'decode-status)
-  (hashtags))
+  (results-tags     :field "hashtags" :translate-with #'decode-tag))
 
 (defmethod print-object ((results results) stream)
   (print-unreadable-object (results stream :type T)
     (format stream
-            "account ~a statuses ~a"
+            "account ~a statuses ~a hashtags ~a"
             (results-accounts results)
-            (results-statuses results))))
+            (results-statuses results)
+            (results-tags results))))
 
 (define-entity status-params
   (text)

--- a/package.lisp
+++ b/package.lisp
@@ -198,7 +198,7 @@
    #:results
    #:results-accounts
    #:results-statuses
-   #:hashtags
+   #:results-tags
    #:status-params
    #:text
    #:in-reply-to-id


### PR DESCRIPTION
Hi @Shinmera !

Note that i have actually changed the name of a slot from `hashtags` to `results-tags` to match the name of the other two slots of the entity `results`, i leave to you the decision to keep the name change, otherwise i can easily revert the name to the old value (`hashtags`).

Bye and happy ELS!

C.