### PR TITLE
 prevent fails to authorize on mastodon.social

### DIFF
--- a/client.lisp
+++ b/client.lisp
@@ -61,7 +61,9 @@
 (defmethod shared-initialize :after ((client client) slots &key)
   (when (access-token client)
     (let ((ideal-class (case (max-api-version client)
-                         ((2 3) (find-class 'v2:client))
+                         (2 (find-class 'v2:client))
+                         (3 (warn "Version 3 of the API is in progress, using version 2 of the client")
+                          (find-class 'v2:client))
                          (1 (find-class 'client))
                          (otherwise
                           (error "Unsupported API version: ~a (supported are versions 1, 2 and 3 in development)."


### PR DESCRIPTION
Hi @Shinmera !

For some reasons the API version supported by `mastodon.social` is 3.

As the library supports only the stable version of the mastodon API, this version is unsupported and `tooter` fails the authentication (actually authentications succeeds on the server, just the client is not able to recognizes a supported API version).

I checked the official documentation and no mention of version 3 of the API could be found.

Instead of let the client fails, i modified the code to kind of "support" version 3 of the API, as no actual problem arose connecting to mastodon.social with tooter so far.

As new versions of the server will be released (ad documentation updated) we could track the new API version.

Please consider merging.

Bye!
C.