### PR TITLE
Update for API v6

### DIFF
--- a/client.lisp
+++ b/client.lisp
@@ -60,17 +60,20 @@
 
 (defclass v2:client (client) ())
 
+(defclass v6:client (v2:client) ())
+
 (defmethod shared-initialize :after ((client client) slots &key)
   (when (access-token client)
     (let ((ideal-class (case (max-api-version client)
-                         (2 (find-class 'v2:client))
-                         (3 (warn "Version 3 of the API is in progress, using version 2 of the client")
-                          (find-class 'v2:client))
+                         ('(2 3 4 5) (find-class 'v2:client))
+                         (6
+                          (warn "Version 3 of the API is in progress, using version 2 of the client")
+                          (find-class 'v6:client))
                          (1 (find-class 'client))
                          (otherwise
-                          (warn "Unsupported API version: ~a (supported are versions 1, 2 and 3 in development)."
+                          (warn "Unsupported API version: ~a (supported are versions <= 6)"
                                 (max-api-version client))
-                          (find-class 'v2:client)))))
+                          (find-class 'v6:client)))))
       (unless (eq ideal-class (class-of client))
         (change-class client ideal-class)))))
 

--- a/client.lisp
+++ b/client.lisp
@@ -65,11 +65,10 @@
 (defmethod shared-initialize :after ((client client) slots &key)
   (when (access-token client)
     (let ((ideal-class (case (max-api-version client)
+                         (1 (find-class 'client))
                          ('(2 3 4 5) (find-class 'v2:client))
                          (6
-                          (warn "Version 3 of the API is in progress, using version 2 of the client")
                           (find-class 'v6:client))
-                         (1 (find-class 'client))
                          (otherwise
                           (warn "Unsupported API version: ~a (supported are versions <= 6)"
                                 (max-api-version client))

--- a/client.lisp
+++ b/client.lisp
@@ -65,8 +65,10 @@
 (defmethod shared-initialize :after ((client client) slots &key)
   (when (access-token client)
     (let ((ideal-class (case (max-api-version client)
-                         (1 (find-class 'client))
-                         ('(2 3 4 5) (find-class 'v2:client))
+                         (1
+                          (find-class 'client))
+                         ('(2 3 4 5)
+                          (find-class 'v2:client))
                          (6
                           (find-class 'v6:client))
                          (otherwise

--- a/objects-v6.lisp
+++ b/objects-v6.lisp
@@ -1,0 +1,31 @@
+(in-package #:tooter-client-v6)
+
+(tooter:define-entity quote-state
+  (state :translate-with #'tooter:to-keyword))
+
+(tooter:define-entity (status-quote (quote-state))
+  (status :translate-with #'decode-status))
+
+(defmethod print-object ((object status-quote) stream)
+  (print-unreadable-object (object stream :type T)
+    (format t "quote state ~a " (state object))
+    (tooter::present (status object) stream)))
+
+(tooter:define-entity (status-shallow-quote (quote-state))
+  (status-id :field "status_id"))
+
+(defmethod print-object ((object status-shallow-quote) stream)
+  (print-unreadable-object (object stream :type T)
+    (format t
+            "quote state ~a id ~a"
+            (state object)
+            (status-id object))))
+
+(defun %decode-quoted-status (quoted-data)
+  (let ((shallowp (tooter::getj quoted-data "status_id")))
+    (if shallowp
+        (tooter:decode-entity 'status-shallow-quote quoted-data)
+        (tooter:decode-entity 'status-quote quoted-data))))
+
+(tooter:define-entity (status (tooter-objects:status))
+  (quoted-status :fields "quote" :nullable T :translate-with #'%decode-quoted-status))

--- a/objects-v6.lisp
+++ b/objects-v6.lisp
@@ -29,3 +29,51 @@
 
 (tooter:define-entity (status (tooter-objects:status))
   (quoted-status :fields "quote" :nullable T :translate-with #'%decode-quoted-status))
+
+(define-entity instance-rule
+  (id)
+  (text)
+  (hint)
+  (translations :nullable T))
+
+(defmethod print-object ((instance-rule instance-rule) stream)
+  (print-unreadable-object (instance-rule stream :type T)
+    (format stream
+            "rule #~a text ~s hint ~s translations ~s"
+            (id instance-rule)
+            (text instance-rule)
+            (hint instance-rule)
+            (translations instance-rule))))
+
+(defun %decode-registrations (data)
+  (let ((registrations data))
+    (when (hash-table-p registrations)
+      (list :enabled (gethash "enabled" registrations)
+            :approval-required (gethash "approval_required" registrations)
+            :message (gethash "message" registrations)
+            :min-age (gethash "min_age" registrations)
+            :reason-required (gethash "reason_required" registrations)))))
+
+(define-entity instance
+  (domain)
+  (title)
+  (version)
+  (source-url :field "source_url")
+  (description)
+  (usage :translate-with #'tooter::%decode-usage)
+  (thumbnail :nullable T :translate-with #'tooter::%decode-thumbnail)
+  (icon :translate-with #'tooter::decode-instance-icon)
+  (languages :translate-with #'tooter::translate-languages)
+  (configuration :translate-with #'tooter::%decode-configuration)
+  (registrations :translate-with #'%decode-registrations)
+  (api-versions :field "api_versions" :translate-with #'tooter::%decode-api-versions)
+  (contact :translate-with #'tooter::%decode-contact)
+  (rules :translate-with #'tooter::decode-instance-rule))
+
+(defmethod print-object ((instance instance) stream)
+  (print-unreadable-object (instance stream :type T)
+    (format stream
+            "~s ~a configuration ~a"
+            (title instance)
+            (domain instance)
+            (configuration instance))))

--- a/objects.lisp
+++ b/objects.lisp
@@ -639,6 +639,26 @@
   (print-unreadable-object (status-tag stream :type T)
     (format stream "name ~a url ~a" (name status-tag) (url status-tag))))
 
+(define-entity status-quote
+  (state)
+  (status :translate-with #'decode-status))
+
+(defmethod print-object ((object status-quote) stream)
+  (print-unreadable-object (object stream :type T)
+    (format t "quote state ~a " (state object))
+    (present (status object) stream)))
+
+(define-entity status-shallow-quote
+  (state)
+  (status-id :field "status_id"))
+
+(defmethod print-object ((object status-shallow-quote) stream)
+  (print-unreadable-object (object stream :type T)
+    (format t
+            "quote state ~a id ~a"
+            (state object)
+            (status-id object))))
+
 (define-entity status
   (id)
   (uri)

--- a/package.lisp
+++ b/package.lisp
@@ -481,6 +481,8 @@
    #:follow-tag
    #:unfollow-tag
    #:tag-information
+   #:feature-tag
+   #:unfeature-tag
    #:timeline-tag
    #:timeline
    #:timeline-link

--- a/package.lisp
+++ b/package.lisp
@@ -531,11 +531,18 @@
   (:use :cl)
   (:export #:client))
 
+(defpackage tooter-client-v6
+  (:nicknames #:org.shirakumo.tooter.client.v6)
+  (:local-nicknames (#:v2 #:org.shirakumo.tooter.client.v2))
+  (:use :cl)
+  (:export #:client))
+
 (defpackage #:tooter
   (:nicknames #:org.shirakumo.tooter)
   (:use #:cl #:tooter-objects #:tooter-queries #:tooter-client)
   (:local-nicknames (#:a  #:alexandria)
-                    (#:v2 #:org.shirakumo.tooter.client.v2))
+                    (#:v2 #:org.shirakumo.tooter.client.v2)
+                    (#:v6 #:org.shirakumo.tooter.client.v6))
   (:shadowing-import-from #:tooter-queries #:block))
 
 (dolist (package '(#:tooter-objects #:tooter-queries #:tooter-client))

--- a/package.lisp
+++ b/package.lisp
@@ -470,6 +470,9 @@
    #:favourite
    #:unfavourite
    #:endorsements
+   #:featured-accounts
+   #:feature-account
+   #:unfeature-account
    #:pin
    #:unpin
    #:mute-conversation

--- a/package.lisp
+++ b/package.lisp
@@ -547,7 +547,10 @@
    #:status-shallow-quote
    #:status
    #:decode-status
-   #:state))
+   #:state
+   #:instance-rule
+   #:translations
+   #:decode-instance))
 
 (defpackage #:tooter
   (:nicknames #:org.shirakumo.tooter)

--- a/package.lisp
+++ b/package.lisp
@@ -534,8 +534,15 @@
 (defpackage tooter-client-v6
   (:nicknames #:org.shirakumo.tooter.client.v6)
   (:local-nicknames (#:v2 #:org.shirakumo.tooter.client.v2))
-  (:use :cl)
-  (:export #:client))
+  (:use #:cl #:tooter-objects)
+  (:shadow #:tooter-objects #:status)
+  (:export
+   #:client
+   #:status-quote
+   #:status-shallow-quote
+   #:status
+   #:decode-status
+   #:state))
 
 (defpackage #:tooter
   (:nicknames #:org.shirakumo.tooter)

--- a/queries.lisp
+++ b/queries.lisp
@@ -320,7 +320,7 @@
   (assert (stringp id))
   (assert (stringp title))
   (check-filter-context context)
-  (check-filter-action filter-action)
+  (check-filter-action client filter-action)
   (decode-filter (apply #'submit
                         client
                         (format NIL "/api/v2/filters/~a" id)
@@ -627,6 +627,17 @@
 
 (defmethod update-media ((client client) (attachment attachment) &rest args &key &allow-other-keys)
   (apply #'update-media client (id attachment) args))
+
+
+(defmethod delete-media ((client v6:client) (attachment string))
+  (submit client
+          (format NIL "/api/v1/media/~a" attachment)
+          :http-method :delete))
+
+(defmethod delete-media ((client v6:client) (attachment attachment))
+  (submit client
+          (format NIL "/api/v1/media/~a" (id attachment))
+          :http-method :delete))
 
 ;;; Mutes
 
@@ -996,6 +1007,17 @@
 
 (defmethod delete-status ((client client) (status status))
   (delete-status client (id status)))
+
+
+(defmethod delete-status ((client v6:client) (status string))
+  (submit client
+          (format NIL "/api/v1/statuses/~a" status)
+          :http-method :delete))
+
+(defmethod delete-status ((client v6:client) (status status))
+  (submit client
+          (format NIL "/api/v1/statuses/~a" (id status))
+          :http-method :delete))
 
 (defmethod edit-status ((client client) (status status) (text string) &key media (sensitive NIL s-p) spoiler-text language poll-options poll-expire-seconds (poll-multiple NIL m-p) (poll-hide-totals NIL h-p))
   (edit-status client

--- a/queries.lisp
+++ b/queries.lisp
@@ -1094,6 +1094,25 @@
 (defmethod tag-information ((client client) (tag string))
   (decode-tag (query client (format NIL "/api/v1/tags/~a" tag))))
 
+
+(defmethod feature-tag ((client v6:client) (tag string))
+  (decode-relationship (submit client
+                               (format NIL
+                                       "/api/v1/tags/~a/feature"
+                                       tag))))
+
+(defmethod feature-tag ((client v6:client) (tag tag))
+  (feature-tag client (name tag)))
+
+(defmethod unfeature-tag ((client v6:client) (tag string))
+  (decode-relationship (submit client
+                               (format NIL
+                                       "/api/v1/tags/~a/unfeature"
+                                       tag))))
+
+(defmethod unfeature-tag ((client v6:client) (tag tag))
+  (unfeature-tag client (name tag)))
+
 ;;; Timelines
 
 (defgeneric %timeline (client url &key local only-media max-id since-id min-id limit other-args))

--- a/queries.lisp
+++ b/queries.lisp
@@ -1016,6 +1016,14 @@
                                        "/api/v1/accounts/~a/unendorse"
                                        account-id))))
 
+(defmethod set-private-note ((client v6:client) (account-id string) (comment string))
+  (decode-relationship (submit
+                        client
+                        (format NIL
+                                "/api/v1/accounts/~a/note"
+                                account-id)
+                        :comment "")))
+
 (defmethod pin ((client client) (id string))
   (decode-status (submit client (format NIL "/api/v1/statuses/~a/pin" id))))
 

--- a/queries.lisp
+++ b/queries.lisp
@@ -998,6 +998,24 @@
 (defmethod endorsements ((client client))
   (decode-account (query client "/api/v1/endorsements")))
 
+(defmethod featured-accounts ((client v6:client) (account-id string))
+  (decode-account (query client
+                         (format NIL
+                                 "/api/v1/accounts/~a/endorsements"
+                                 account-id))))
+
+(defmethod feature-account ((client v6:client) (account-id string))
+  (decode-relationship (submit client
+                               (format NIL
+                                       "/api/v1/accounts/~a/endorse"
+                                       account-id))))
+
+(defmethod unfeature-account ((client v6:client) (account-id string))
+  (decode-relationship (submit client
+                               (format NIL
+                                       "/api/v1/accounts/~a/unendorse"
+                                       account-id))))
+
 (defmethod pin ((client client) (id string))
   (decode-status (submit client (format NIL "/api/v1/statuses/~a/pin" id))))
 

--- a/queries.lisp
+++ b/queries.lisp
@@ -508,6 +508,9 @@
 (defmethod instance ((client v2:client))
   (decode-instance (query client "/api/v2/instance")))
 
+(defmethod instance ((client v6:client))
+  (v6:decode-instance (query client "/api/v2/instance")))
+
 (defmethod peers ((client client))
   (query client "/api/v1/instance/peers"))
 
@@ -1000,24 +1003,26 @@
         (decode-scheduled-status results-entity)
         (decode-status results-entity))))
 
-(defmethod delete-status ((client client) (id string))
+(defgeneric delete-status (client id &key &allow-other-keys))
+
+(defmethod delete-status ((client client) (id string) &key &allow-other-keys)
   (submit client (format NIL "/api/v1/statuses/~a" id)
           :http-method :delete)
   T)
 
-(defmethod delete-status ((client client) (status status))
+(defmethod delete-status ((client client) (status status) &key &allow-other-keys)
   (delete-status client (id status)))
 
-
-(defmethod delete-status ((client v6:client) (status string))
+(defmethod delete-status ((client v6:client) (status string)
+                          &key (delete-media NIL da-p) &allow-other-keys)
   (submit client
           (format NIL "/api/v1/statuses/~a" status)
+          :delete-media (coerce-boolean delete-media da-p)
           :http-method :delete))
 
-(defmethod delete-status ((client v6:client) (status status))
-  (submit client
-          (format NIL "/api/v1/statuses/~a" (id status))
-          :http-method :delete))
+(defmethod delete-status ((client v6:client) (status status)
+                          &key (delete-media NIL) &allow-other-keys)
+  (delete-status client (id status) :delete-media delete-media))
 
 (defmethod edit-status ((client client) (status status) (text string) &key media (sensitive NIL s-p) spoiler-text language poll-options poll-expire-seconds (poll-multiple NIL m-p) (poll-hide-totals NIL h-p))
   (edit-status client

--- a/queries.lisp
+++ b/queries.lisp
@@ -269,8 +269,13 @@
 (defmethod filter ((client v2:client) (filter filter))
   (filter client (id filter)))
 
-(defun check-filter-action (value)
+(defgeneric check-filter-action (object value))
+
+(defmethod check-filter-action ((object v2:client) value)
   (assert (member value '("warn" "hide") :test #'string=)))
+
+(defmethod check-filter-action ((object v6:client) value)
+  (assert (member value '("warn" "hide" "blur") :test #'string=)))
 
 (defun check-filter-context (value)
   (assert (consp value))
@@ -290,7 +295,7 @@
                             (filter-action "hide")
                             (fields '()))
   (check-filter-context context)
-  (check-filter-action filter-action)
+  (check-filter-action client filter-action)
   (assert (stringp title))
   (assert (consp context))
   (decode-filter (apply #'submit

--- a/queries.lisp
+++ b/queries.lisp
@@ -865,7 +865,7 @@
            :limit limit)))
 
 (defmethod rebloggers ((client client) (status status) &rest args)
-  (apply #'rebloggers client (id status) args &key &allow-other-keys))
+  (apply #'rebloggers client (id status) args))
 
 (defmethod favouriters ((client client) (id string) &key max-id since-id (limit 40))
   (check-type max-id (or null string))

--- a/tooter.asd
+++ b/tooter.asd
@@ -11,6 +11,7 @@
                (:file "link-header-parser")
                (:file "client")
                (:file "objects")
+               (:file "objects-v6")
                (:file "queries")
                (:file "documentation"))
   :depends-on (:alexandria


### PR DESCRIPTION
Hi!

I have updated the library to use the new API version (6), note that:

- I have modified the `define-entity` macro to allows super-classes;
- I have moved classes and some methods for version 6 objects in a separate file, because the file `objects.lip` stated to became a bit crowded;
- i have added a special variable to make easier to debug calls to endpoints;
- I have added a keyword parameter to `%request`, for debugging purposes;
- i think i have fixed the logic for choosing an API implementation (see: #58).

Bye!
C.  
